### PR TITLE
test the kvs implementation of bbsr

### DIFF
--- a/inferelator_ng/bbsr_python.py
+++ b/inferelator_ng/bbsr_python.py
@@ -56,21 +56,28 @@ def BBSR(X, Y, clr_mat, nS, no_pr_val, weights_mat, prior_mat, kvs, rank, ownChe
     # deterministic.
     s = []
     limit = G
+    print 'how many genes? {}'.format(limit)
     for j in range(limit):
-        if ownCheck.next():
+        temp_next = ownCheck.next()
+        print 'temp_next: {}'.format(temp_next)
+        if temp_next:
             # busy work
             s.append(BBSRforOneGeneWrapper(j))
+            print ('in per-gene loop. s is : {}, rank is: {}'.format(s, rank))
     # Report partial result.
     kvs.put('plist',(rank,s))
     # One participant gathers the partial results and generates the final
     # output.
+    print 'rank: {}'.format(rank)
     if 0 == rank:
         s=[]
         workers=int(os.environ['SLURM_NTASKS'])
+        print workers
         for p in range(workers):
             wrank,ps = kvs.get('plist')
             print ('got', wrank, len(ps))
             s.extend(ps)
+            print s
         print ('final s', len(s))
         return s
     else:
@@ -289,11 +296,15 @@ class BBSR_runner:
         weights_mat = prior_mat * 0 + no_prior_weight
         weights_mat = weights_mat.mask(prior_mat != 0, other=prior_weight)
 
-        x = BBSR(X, Y, clr_mat, nS, no_pr_val, weights_mat, prior_mat, kvs, rank, ownCheck)
-        if rank: return (None,None)
+        run_result = BBSR(X, Y, clr_mat, nS, no_pr_val, weights_mat, prior_mat, kvs, rank, ownCheck)
+        if rank: 
+            print 'rank: {}'.format(rank)
+            return (None,None)
+        print 'run_result: {}'.format(run_result)
         bs_betas = pd.DataFrame(np.zeros((Y.shape[0],prior_mat.shape[1])),index=Y.index,columns=prior_mat.columns)
         bs_betas_resc = bs_betas.copy(deep=True)
-        for res in x:
+        for res in run_result:
+            print bs_betas
             bs_betas.ix[res['ind'],X.index.values[res['pp']]] = res['betas']
             bs_betas_resc.ix[res['ind'],X.index.values[res['pp']]] = res['betas_resc']
         return (bs_betas, bs_betas_resc)

--- a/inferelator_ng/bbsr_python.py
+++ b/inferelator_ng/bbsr_python.py
@@ -7,7 +7,7 @@ from scipy import special
 import multiprocessing
 from functools import partial
 import os, sys
-import utils 
+from . import utils
 
 # Wrapper function for BBSRforOneGene that's called in BBSR
 gx, gy, gpp, gwm, gns = None, None, None, None, None

--- a/inferelator_ng/bbsr_python.py
+++ b/inferelator_ng/bbsr_python.py
@@ -267,7 +267,7 @@ def PredictErrorReduction(y, x, beta):
         x_tmp = x[:,pred_tmp_index]
 
         bhat = np.linalg.solve(np.dot(x_tmp.transpose(),x_tmp),np.dot(x_tmp.transpose(),y))
-        
+
         residuals = np.subtract(y,np.dot(x_tmp,bhat))
         sigma_sq = np.var(residuals,ddof=1)
         err_red[i] = 1 - (sigma_sq_full / sigma_sq)
@@ -283,8 +283,8 @@ class BBSR_runner:
         weights_mat = prior_mat * 0 + no_prior_weight
         weights_mat = weights_mat.mask(prior_mat != 0, other=prior_weight)
 
-        run_result = BBSR(X, Y, clr_mat, nS, no_pr_val, weights_mat, prior_mat, kvs, rank, ownCheck)
-        if rank: 
+        run_result = BBSR(X, Y, clr, n, no_prior_weight, weights_mat, prior_mat, kvs, rank, ownCheck)
+        if rank:
             return (None,None)
         bs_betas = pd.DataFrame(np.zeros((Y.shape[0],prior_mat.shape[1])),index=Y.index,columns=prior_mat.columns)
         bs_betas_resc = bs_betas.copy(deep=True)

--- a/inferelator_ng/bbsr_python.py
+++ b/inferelator_ng/bbsr_python.py
@@ -57,11 +57,9 @@ def BBSR(X, Y, clr_mat, nS, no_pr_val, weights_mat, prior_mat, kvs, rank, ownChe
     s = []
     limit = G
     for j in range(limit):
-        if not ownCheck or ownCheck.next():
+        if ownCheck.next():
             # busy work
             s.append(BBSRforOneGeneWrapper(j))
-    if not kvs:
-        return s
     # Report partial result.
     kvs.put('plist',(rank,s))
     # One participant gathers the partial results and generates the final

--- a/inferelator_ng/bbsr_tfa_workflow.py
+++ b/inferelator_ng/bbsr_tfa_workflow.py
@@ -49,7 +49,7 @@ class BBSR_TFA_Workflow(WorkflowBase):
             else:
                 (self.clr_matrix, self.mi_matrix) = kvs.view('mi %d'%idx)
             print('Calculating betas using BBSR')
-            ownCheck = utils.own(kvs, rank, chunk=25, reset=idx!=0)
+            ownCheck = utils.own(kvs, rank, chunk=25)
             current_betas,current_rescaled_betas = self.regression_driver.run(X, Y, self.clr_matrix, self.priors_data,kvs,rank,ownCheck)
             if rank: continue
             betas.append(current_betas)

--- a/inferelator_ng/tests/test_bbsr.py
+++ b/inferelator_ng/tests/test_bbsr.py
@@ -24,8 +24,8 @@ class TestBBSRrunnerPython(unittest.TestCase):
             self.kvs = KVSClient()
         except Exception as e:
             if e.message == 'Missing host':
-                print 'Test test_bbsr.py exiting since KVS host is not running'
-                print 'Try rerunning tests with python $LOCALREPO/kvsstcp.py --execcmd "nosetests  --nocapture -v"'
+                print('Test test_bbsr.py exiting since KVS host is not running')
+                print('Try rerunning tests with python $LOCALREPO/kvsstcp.py --execcmd "nosetests  --nocapture -v"')
                 self.missing_kvs_host = True
 
         # Mock out Slurm process IDs so that KVS can access this process ID in bbsr_python.py

--- a/inferelator_ng/tests/test_bbsr.py
+++ b/inferelator_ng/tests/test_bbsr.py
@@ -23,7 +23,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
         try:
             self.kvs = KVSClient()
         except Exception as e:
-            if e.message == 'Missing host':
+            if str(e) == 'Missing host':
                 print('Test test_bbsr.py exiting since KVS host is not running')
                 print('Try rerunning tests with python $LOCALREPO/kvsstcp.py --execcmd "nosetests  --nocapture -v"')
                 self.missing_kvs_host = True

--- a/inferelator_ng/tests/test_bbsr.py
+++ b/inferelator_ng/tests/test_bbsr.py
@@ -7,8 +7,6 @@ from subprocess import CalledProcessError
 from .. import bbsr_python
 from .. import utils
 
-kvsclient = KVSClient()
-print 'INITIALIZING KVS CLIENT'
 my_dir = os.path.dirname(__file__)
 
 class TestBBSRrunnerPython(unittest.TestCase):
@@ -16,23 +14,27 @@ class TestBBSRrunnerPython(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestBBSRrunnerPython, self).__init__(*args, **kwargs)
         # Extra behavior: only run if KVSClient can reach the host:
-        #try:
-        #    self.kvs = kvsclient
-        #except Exception as e:
-        #    if e.message == 'Missing host':
-        #        print 'Test test_bbsr.py exiting since KVS host is not running'
-        #        print 'Try rerunning tests with python $LOCALREPO/kvsstcp.py --execcmd "nosetests  --nocapture -v"'
-        #        unittest.main(exit=False)
-#
+        try:
+            self.kvs = KVSClient()
+        except Exception as e:
+            if e.message == 'Missing host':
+                print 'Test test_bbsr.py exiting since KVS host is not running'
+                print 'Try rerunning tests with python $LOCALREPO/kvsstcp.py --execcmd "nosetests  --nocapture -v"'
+                unittest.main(exit=False)
+
+        # Mock out Slurm process IDs so that KVS can access this process ID in bbsr_python.py
+        os.environ['SLURM_PROCID'] = str(0)   
+        os.environ['SLURM_NTASKS'] = str(1)
+
     def setUp(self):
         # Check for os.environ['SLURM_NTASKS']
         self.rank = 0
         self.brd = bbsr_python.BBSR_runner()
-        # Extra behavior: only run if this is defined:
-        
+     
 
     def run_bbsr(self):
-        return self.brd.run(self.X, self.Y, self.clr, self.priors, rank=self.rank, kvs=kvsclient, ownCheck = utils.own(kvsclient, self.rank, chunk=1))
+        return self.brd.run(self.X, self.Y, self.clr, self.priors, rank=self.rank, \
+                 kvs=self.kvs, ownCheck = utils.ownCheck(self.kvs, self.rank))
 
     def set_all_zero_priors(self):
         self.priors =  pd.DataFrame([[0, 0],[0, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2'])
@@ -150,7 +152,6 @@ class TestBBSRrunnerPython(unittest.TestCase):
         self.X = pd.DataFrame([[1, 2], [1, 2]], index = ['gene1', 'gene2'], columns = ['ss1', 'ss2'])
         self.Y = pd.DataFrame([[1, 2], [1, 2]], index = ['gene1', 'gene2'], columns = ['ss1', 'ss2'])
         self.clr = pd.DataFrame([[.1, .1],[.1, .2]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2'])
-        import pdb; pdb.set_trace()
         (betas, resc) = self.run_bbsr()
         self.assert_matrix_is_square(2, betas)
         self.assert_matrix_is_square(2, resc)
@@ -179,6 +180,5 @@ class TestBBSRrunnerPython(unittest.TestCase):
         (betas, resc) = self.run_bbsr()
         self.assert_matrix_is_square(2, betas)
         self.assert_matrix_is_square(2, resc)
-        import pdb; pdb.set_trace()
         pdt.assert_frame_equal(betas, pd.DataFrame([[0, 1],[1, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
         pdt.assert_frame_equal(resc, pd.DataFrame([[0, 1],[1, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))

--- a/inferelator_ng/tests/test_bbsr.py
+++ b/inferelator_ng/tests/test_bbsr.py
@@ -9,6 +9,12 @@ from .. import utils
 
 my_dir = os.path.dirname(__file__)
 
+def should_skip():
+    if ("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true"):
+        return True
+    else:
+        return False
+
 class TestBBSRrunnerPython(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
@@ -20,7 +26,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
             if e.message == 'Missing host':
                 print 'Test test_bbsr.py exiting since KVS host is not running'
                 print 'Try rerunning tests with python $LOCALREPO/kvsstcp.py --execcmd "nosetests  --nocapture -v"'
-                self.fail("No KVS Client")
+                self.missing_kvs_host = True
 
         # Mock out Slurm process IDs so that KVS can access this process ID in bbsr_python.py
         os.environ['SLURM_PROCID'] = str(0)   
@@ -30,8 +36,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
         # Check for os.environ['SLURM_NTASKS']
         self.rank = 0
         self.brd = bbsr_python.BBSR_runner()
-     
-
+    
     def run_bbsr(self):
         return self.brd.run(self.X, self.Y, self.clr, self.priors, rank=self.rank, \
                  kvs=self.kvs, ownCheck = utils.ownCheck(self.kvs, self.rank))
@@ -45,6 +50,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
     def assert_matrix_is_square(self, size, matrix):
         self.assertEqual(matrix.shape, (size, size))
 
+    @unittest.skipIf(should_skip(), "Skipping this test on Travis CI.")
     def test_two_genes(self):
         self.set_all_zero_priors()
         self.set_all_zero_clr()
@@ -65,6 +71,8 @@ class TestBBSRrunnerPython(unittest.TestCase):
         self.Y = pd.DataFrame([0], index = ['gene1'], columns = ['ss'])
         self.assertRaises(CalledProcessError, self.brd.run, self.X, self.Y, self.clr, self.priors)
     '''
+
+    @unittest.skipIf(should_skip(), "Skipping this test on Travis CI.")
     def test_two_genes_nonzero(self):
         self.set_all_zero_priors()
         self.set_all_zero_clr()
@@ -92,6 +100,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
             0     0
     """)
     '''
+    @unittest.skipIf(should_skip(), "Skipping this test on Travis CI.")
     def test_two_genes_nonzero_clr_nonzero(self):
         self.set_all_zero_priors()
         self.X = pd.DataFrame([1, 2], index = ['gene1', 'gene2'], columns = ['ss'])
@@ -103,6 +112,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
         pdt.assert_frame_equal(betas, pd.DataFrame([[0, 0],[0, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
         pdt.assert_frame_equal(resc, pd.DataFrame([[0, 0],[0, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
 
+    @unittest.skipIf(should_skip(), "Skipping this test on Travis CI.")
     def test_two_genes_nonzero_clr_two_conditions_negative_influence(self):
         self.set_all_zero_priors()
         self.X = pd.DataFrame([[1, 2], [2, 1]], index = ['gene1', 'gene2'], columns = ['ss1', 'ss2'])
@@ -114,6 +124,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
         pdt.assert_frame_equal(betas, pd.DataFrame([[0, -1],[-1, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
         pdt.assert_frame_equal(resc, pd.DataFrame([[0, 1],[1, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
 
+    @unittest.skipIf(should_skip(), "Skipping this test on Travis CI.")
     def test_two_genes_nonzero_clr_two_conditions_zero_gene1_negative_influence(self):
         self.set_all_zero_priors()
         self.X = pd.DataFrame([[0, 2], [2, 0]], index = ['gene1', 'gene2'], columns = ['ss1', 'ss2'])
@@ -125,6 +136,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
         pdt.assert_frame_equal(betas, pd.DataFrame([[0, -1],[-1, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
         pdt.assert_frame_equal(resc, pd.DataFrame([[0, 1],[1, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
 
+    @unittest.skipIf(should_skip(), "Skipping this test on Travis CI.")
     def test_two_genes_zero_clr_two_conditions_zero_betas(self):
         self.set_all_zero_priors()
         self.set_all_zero_clr()
@@ -136,6 +148,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
         pdt.assert_frame_equal(betas, pd.DataFrame([[0, 0],[0, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
         pdt.assert_frame_equal(resc, pd.DataFrame([[0, 0],[0, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
 
+    @unittest.skipIf(should_skip(), "Skipping this test on Travis CI.")
     def test_two_genes_zero_clr_two_conditions_zero_gene1_zero_betas(self):
         self.set_all_zero_priors()
         self.set_all_zero_clr()
@@ -147,6 +160,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
         pdt.assert_frame_equal(betas, pd.DataFrame([[0, 0],[0, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
         pdt.assert_frame_equal(resc, pd.DataFrame([[0, 0],[0, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
 
+    @unittest.skipIf(should_skip(), "Skipping this test on Travis CI.")
     def test_two_genes_nonzero_clr_two_conditions_positive_influence(self):
         self.set_all_zero_priors()
         self.X = pd.DataFrame([[1, 2], [1, 2]], index = ['gene1', 'gene2'], columns = ['ss1', 'ss2'])
@@ -172,6 +186,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
         result = bbsr_python.PredictErrorReduction(self.Y, self.X, betas)
         self.assertTrue((result == [ 0.,  0.]).all())
 
+    @unittest.skipIf(should_skip(), "Skipping this test on Travis CI.")
     def test_two_genes_nonzero_clr_two_conditions_zero_gene1_positive_influence(self):
         self.set_all_zero_priors()
         self.X = pd.DataFrame([[0, 2], [0, 2]], index = ['gene1', 'gene2'], columns = ['ss1', 'ss2'])

--- a/inferelator_ng/tests/test_bbsr.py
+++ b/inferelator_ng/tests/test_bbsr.py
@@ -20,7 +20,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
             if e.message == 'Missing host':
                 print 'Test test_bbsr.py exiting since KVS host is not running'
                 print 'Try rerunning tests with python $LOCALREPO/kvsstcp.py --execcmd "nosetests  --nocapture -v"'
-                unittest.main(exit=False)
+                self.fail("No KVS Client")
 
         # Mock out Slurm process IDs so that KVS can access this process ID in bbsr_python.py
         os.environ['SLURM_PROCID'] = str(0)   

--- a/inferelator_ng/tests/test_bbsr.py
+++ b/inferelator_ng/tests/test_bbsr.py
@@ -7,28 +7,32 @@ from subprocess import CalledProcessError
 from .. import bbsr_python
 from .. import utils
 
+kvsclient = KVSClient()
+print 'INITIALIZING KVS CLIENT'
 my_dir = os.path.dirname(__file__)
 
 class TestBBSRrunnerPython(unittest.TestCase):
 
-    def setUp(self):
+    def __init__(self, *args, **kwargs):
+        super(TestBBSRrunnerPython, self).__init__(*args, **kwargs)
         # Extra behavior: only run if KVSClient can reach the host:
-        try:
-            self.kvs = KVSClient()
-        except Exception as e:
-            if e.message == 'Missing host':
-                print 'Test test_bbsr.py exiting since KVS host is not running'
-                print 'Try rerunning tests with python $LOCALREPO/kvsstcp.py --execcmd "nosetests  --nocapture -v"'
-                unittest.main(exit=False)
+        #try:
+        #    self.kvs = kvsclient
+        #except Exception as e:
+        #    if e.message == 'Missing host':
+        #        print 'Test test_bbsr.py exiting since KVS host is not running'
+        #        print 'Try rerunning tests with python $LOCALREPO/kvsstcp.py --execcmd "nosetests  --nocapture -v"'
+        #        unittest.main(exit=False)
+#
+    def setUp(self):
         # Check for os.environ['SLURM_NTASKS']
-
         self.rank = 0
         self.brd = bbsr_python.BBSR_runner()
         # Extra behavior: only run if this is defined:
         
 
     def run_bbsr(self):
-        return self.brd.run(self.X, self.Y, self.clr, self.priors, kvs=self.kvs, ownCheck = utils.own(self.kvs, self.rank, chunk=1, reset=0))
+        return self.brd.run(self.X, self.Y, self.clr, self.priors, rank=self.rank, kvs=kvsclient, ownCheck = utils.own(kvsclient, self.rank, chunk=1))
 
     def set_all_zero_priors(self):
         self.priors =  pd.DataFrame([[0, 0],[0, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2'])
@@ -146,6 +150,7 @@ class TestBBSRrunnerPython(unittest.TestCase):
         self.X = pd.DataFrame([[1, 2], [1, 2]], index = ['gene1', 'gene2'], columns = ['ss1', 'ss2'])
         self.Y = pd.DataFrame([[1, 2], [1, 2]], index = ['gene1', 'gene2'], columns = ['ss1', 'ss2'])
         self.clr = pd.DataFrame([[.1, .1],[.1, .2]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2'])
+        import pdb; pdb.set_trace()
         (betas, resc) = self.run_bbsr()
         self.assert_matrix_is_square(2, betas)
         self.assert_matrix_is_square(2, resc)

--- a/inferelator_ng/tests/test_tfa.py
+++ b/inferelator_ng/tests/test_tfa.py
@@ -138,12 +138,12 @@ class TestTFA(unittest.TestCase):
     def test_tfa_default_using_mouse_th17(self):
         self.setup_mouse_th17()
         activities = self.tfa_object.compute_transcription_factor_activity()
-        np.testing.assert_array_almost_equal_nulp(activities.values,
+        np.testing.assert_allclose(activities.values,
             np.array([[1.706100, 1.765225, 1.739675, 1.791075, 1.70055], 
                 [8.160000, 8.553600, 7.765000, 7.890300, 8.08710], 
                 [-1.257265, -1.611675, -1.348145, -1.196210, -1.35857],
                 [1.706100, 1.765225, 1.739675, 1.791075, 1.70055]]),
-            units_in_the_last_place_tolerance)
+            atol=1e-15)
         # Assert the final priors matrix has no self- interactions
         np.testing.assert_equal(self.tfa_object.prior.values, np.array([[1,0,0,1], 
             [0,0,0,0], 

--- a/inferelator_ng/utils.py
+++ b/inferelator_ng/utils.py
@@ -43,11 +43,9 @@ def r_path(path):
     """
     return path.replace('\\', '/')
 
-def own(kvs, rank=0, chunk=1, reset=False):
+def ownCheck(kvs, rank, chunk=1):
     # initialize a global counter.                                                                                                               
-    #if reset: kvs.get('count')
     if 0 == rank:
-        if reset: kvs.get('count')
         kvs.put('count', 0)
     checks, lower, upper = 0, -1, -1
     while 1:
@@ -58,6 +56,11 @@ def own(kvs, rank=0, chunk=1, reset=False):
         yield lower <= checks < upper
         checks += 1
 
+def kvsTearDown(kvs, rank):
+    # de-initialize the global counter.        
+    if 0 == rank:
+        # Do a hard reset if rank == 0                                                                                                       
+        kvs.get('count')
 
 class RDriver:
     """

--- a/run_unittests.sh
+++ b/run_unittests.sh
@@ -1,0 +1,16 @@
+REPOSRC=https://github.com/simonsfoundation/kvsstcp
+LOCALREPO=$(pwd)/kvsstcp
+LOCALREPO_VC_DIR=$LOCALREPO/.git
+
+if [ ! -d $LOCALREPO_VC_DIR ]
+then
+    git clone $REPOSRC $LOCALREPO
+else
+    pushd $LOCALREPO
+    git pull $REPOSRC
+    popd
+fi
+
+export PYTHONPATH=$PYTHONPATH:$LOCALREPO
+
+python $LOCALREPO/kvsstcp.py --execcmd "nosetests -v"


### PR DESCRIPTION
There are 2 reasons for working on this:
1) bbsr_python.py has extra code just for testing, which could be simplified if the testing framework used the same utils library as the main codebase. 
2) There are some failing tests when using the kvs client that seem to be real failures, and might be due to unforeseen issues in our kvs integration. For example: ======================================================================
FAIL: test_two_genes_nonzero_clr_two_conditions_zero_gene1_positive_influence (inferelator_ng.tests.test_bbsr.TestBBSRrunnerPython)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ndeveaux/Dev/inferelator_ng/inferelator_ng/tests/test_bbsr.py", line 178, in test_two_genes_nonzero_clr_two_conditions_zero_gene1_positive_influence
    pdt.assert_frame_equal(betas, pd.DataFrame([[0, 1],[1, 0]], index = ['gene1', 'gene2'], columns = ['gene1', 'gene2']).astype(float))
  File "/usr/local/lib/python2.7/site-packages/pandas/util/testing.py", line 1166, in assert_frame_equal
    obj='DataFrame.iloc[:, {0}]'.format(i))
  File "/usr/local/lib/python2.7/site-packages/pandas/util/testing.py", line 1049, in assert_series_equal
    check_less_precise, obj='{0}'.format(obj))
  File "pandas/src/testing.pyx", line 58, in pandas._testing.assert_almost_equal (pandas/src/testing.c:3887)
  File "pandas/src/testing.pyx", line 147, in pandas._testing.assert_almost_equal (pandas/src/testing.c:2769)
  File "/usr/local/lib/python2.7/site-packages/pandas/util/testing.py", line 915, in raise_assert_detail
    raise AssertionError(msg)
AssertionError: DataFrame.iloc[:, 0] are different

DataFrame.iloc[:, 0] values are different (50.0 %)
[left]:  [0.0, 0.0]
[right]: [0.0, 1.0]
