### PR TITLE
Use kvs module

### DIFF
--- a/devnotes.md
+++ b/devnotes.md
@@ -130,7 +130,7 @@ nosetests
 
 The `SKIP_KVS_TESTS` environment variable suppresses tests that require
 external parallelism support from the 
-(KVS package)[https://github.com/flatironinstitute/kvsstcp] because these steps
+[KVS package](https://github.com/flatironinstitute/kvsstcp) because these steps
 require a special invocation (see below).
 
 Output should look like this:

--- a/devnotes.md
+++ b/devnotes.md
@@ -128,7 +128,7 @@ export SKIP_KVS_TESTS=true
 nosetests
 ```
 
-The `SKIP_KVS_TESTS` environment variable suppresses test that require
+The `SKIP_KVS_TESTS` environment variable suppresses tests that require
 external parallelism support from the 
 (KVS package)[https://github.com/flatironinstitute/kvsstcp] because these steps
 require a special invocation (see below).

--- a/devnotes.md
+++ b/devnotes.md
@@ -123,9 +123,15 @@ run
 [nosetests](http://pythontesting.net/framework/nose/nose-introduction/) 
 (this runs the unit tests):
 
-```
+```bash
+export SKIP_KVS_TESTS=true
 nosetests
 ```
+
+The `SKIP_KVS_TESTS` environment variable suppresses test that require
+external parallelism support from the 
+(KVS package)[https://github.com/flatironinstitute/kvsstcp] because these steps
+require a special invocation (see below).
 
 Output should look like this:
 
@@ -142,9 +148,24 @@ failures the output will be more extensive, describing which tests failed and ho
 
 For debugging purposes it is sometimes useful to use `print` statements and invoke
 nosetests with the `--nocapture` option in order to see the output.
-```
+
+```bash
+export SKIP_KVS_TESTS=true
 nosetests --nocapture
 ```
+
+## Running the unit tests with parallelism support from KVS
+
+You can run the tests including the ones that require KVS using the
+following command line:
+
+```bash
+export SKIP_KVS_TESTS=false
+python -m kvsstcp.kvsstcp --execcmd "nosetests  --nocapture -v"
+```
+
+The resulting output will include print statements from the tests and also log
+statements from the `kvsstcp` manager process.
 
 # Making a contribution to the project
 

--- a/inferelator_ng/__init__.py
+++ b/inferelator_ng/__init__.py
@@ -1,0 +1,1 @@
+# This is the required package __init__ file.  It is intensionally empty

--- a/inferelator_ng/bbsr_tfa_workflow.py
+++ b/inferelator_ng/bbsr_tfa_workflow.py
@@ -11,7 +11,7 @@ from results_processor import ResultsProcessor
 import mi_R
 import bbsr_python
 import datetime
-from kvsclient import KVSClient
+from kvsstcp.kvsclient import KVSClient
 from . import utils
 
 # Connect to the key value store service (its location is found via an

--- a/inferelator_ng/tests/test_bbsr.py
+++ b/inferelator_ng/tests/test_bbsr.py
@@ -9,11 +9,12 @@ from .. import utils
 
 my_dir = os.path.dirname(__file__)
 
-def should_skip():
-    if ("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true"):
-        return True
-    else:
-        return False
+def should_skip(environment_flags=[("TRAVIS", "true"), ("SKIP_KVS_TESTS", "true")]):
+    for (flag, value) in environment_flags:
+        if (flag in os.environ and os.environ[flag] == value):
+            return True
+    # default
+    return False
 
 class TestBBSRrunnerPython(unittest.TestCase):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ scipy>=0.9
 # scikit-learn
 pybedtools
 pandas>=0.18
-
+git+https://github.com/flatironinstitute/kvsstcp


### PR DESCRIPTION
This PR is designed to make the package auto-install correctly and to make
the test suites run properly with or without the KVS process controller.

This PR does a number of closely related things:

- Add the `kvsstcp` package to `requirements.txt`  installed directly from github.  At the moment the code files for KVS seem to be installed "by hand".
- Change the KVS imports to use the `kvsstcp` package as installed by `requirements.txt` rather than use code files installed by hand (?).
- Add an environment variable which allows `nosetests` to optionally skip tests which require KVS.
- Document the use of KVS for testing in the developer notes.

When/if this PR is merged all users will need to rerun `python setup.py install -r requirements.txt`
in order to get KVS installed in the standard location.
