### PR TITLE
Ndv teardown timely

### DIFF
--- a/bsubtilis_bbsr_workflow_runner_with_imports.sh
+++ b/bsubtilis_bbsr_workflow_runner_with_imports.sh
@@ -1,0 +1,4 @@
+export PATH=/mnt/xfs1/bioinfoCentos7/software/installs/R/R-3.1.1/bin:$PATH
+export PATH=/mnt/xfs1/bioinfoCentos7/software/installs/python/anaconda/bin:$PATH
+export PYTHONPATH=~dylan/scc/kvsstcp:/mnt/xfs1/bioinfoCentos7/software/installs/python/anaconda/bin:$PYTHONPATH
+python bsubtilis_bbsr_workflow_runner.py

--- a/inferelator_ng/bbsr_python.py
+++ b/inferelator_ng/bbsr_python.py
@@ -64,7 +64,6 @@ def BBSR(X, Y, clr_mat, nS, no_pr_val, weights_mat, prior_mat, kvs, rank, ownChe
     kvs.put('plist',(rank,s))
     # One participant gathers the partial results and generates the final
     # output.
-    utils.kvsTearDown(kvs, rank)
     if 0 == rank:
         s=[]
         workers=int(os.environ['SLURM_NTASKS'])
@@ -72,6 +71,7 @@ def BBSR(X, Y, clr_mat, nS, no_pr_val, weights_mat, prior_mat, kvs, rank, ownChe
             wrank,ps = kvs.get('plist')
             s.extend(ps)
         print ('final s', len(s))
+        utils.kvsTearDown(kvs, rank)
         return s
     else:
         return None

--- a/inferelator_ng/bbsr_tfa_workflow.py
+++ b/inferelator_ng/bbsr_tfa_workflow.py
@@ -12,6 +12,7 @@ import mi_R
 import bbsr_python
 import datetime
 from kvsstcp.kvsclient import KVSClient
+import pandas as pd
 from . import utils
 
 # Connect to the key value store service (its location is found via an

--- a/workflow_runner_with_imports.sh
+++ b/workflow_runner_with_imports.sh
@@ -1,4 +1,4 @@
 export PATH=/mnt/xfs1/bioinfoCentos7/software/installs/R/R-3.1.1/bin:$PATH
 export PATH=/mnt/xfs1/bioinfoCentos7/software/installs/python/anaconda/bin:$PATH
 export PYTHONPATH=~dylan/scc/kvsstcp:/mnt/xfs1/bioinfoCentos7/software/installs/python/anaconda/bin:$PYTHONPATH
-python bsubtilis_bbsr_workflow_runner.py
+python $1


### PR DESCRIPTION
I'm addressing two issues here:

1) The utils.kvsTearDown function should only be called once all the workers have guaranteed to have finished. Calling kvs.get('plist') enforces that guarantee. This issue only arises non-deterministically (i.e. when some workers are significantly slower than the rank0 worker), so it wasn't detected when we first brought this code live. 

2) R code libraries need to be set manually on the simons cluster, since the default R (version 3.4 and higher) doesn't have the required packages installed 