### PR TITLE
Ndv dont share mi clr but still lock per bootstrap

### DIFF
--- a/inferelator_ng/bbsr_tfa_workflow.py
+++ b/inferelator_ng/bbsr_tfa_workflow.py
@@ -44,11 +44,7 @@ class BBSR_TFA_Workflow(WorkflowBase):
             X = self.activity.ix[:, bootstrap]
             Y = self.response.ix[:, bootstrap]
             print('Calculating MI, Background MI, and CLR Matrix')
-            if 0 == rank:
-                (self.clr_matrix, self.mi_matrix) = self.mi_clr_driver.run(X, Y)
-                kvs.put('mi %d'%idx, (self.clr_matrix, self.mi_matrix))
-            else:
-                (self.clr_matrix, self.mi_matrix) = kvs.view('mi %d'%idx)
+            (self.clr_matrix, self.mi_matrix) = self.mi_clr_driver.run(X, Y)
             print('Calculating betas using BBSR')
             ownCheck = utils.ownCheck(kvs, rank, chunk=25)
             current_betas,current_rescaled_betas = self.regression_driver.run(X, Y, self.clr_matrix, self.priors_data,kvs,rank, ownCheck)

--- a/inferelator_ng/bbsr_tfa_workflow.py
+++ b/inferelator_ng/bbsr_tfa_workflow.py
@@ -47,11 +47,13 @@ class BBSR_TFA_Workflow(WorkflowBase):
             Y = self.response.ix[:, bootstrap]
             print('Calculating MI, Background MI, and CLR Matrix')
             (self.clr_matrix, self.mi_matrix) = self.mi_clr_driver.run(X, Y)
-            print('Calculating betas using BBSR')
+            # Force stdout to flush so that the output is readable from all workers
+            sys.stdout.flush()
             if 0 == rank:
                 kvs.put('bootstrap %d'%idx, 'This is how we stop workers from moving ahead on a new bootstrap')
             else:
                 kvs.view('bootstrap %d'%idx)
+            print('Calculating betas using BBSR')
             ownCheck = utils.ownCheck(kvs, rank, chunk=25)
             current_betas,current_rescaled_betas = self.regression_driver.run(X, Y, self.clr_matrix, self.priors_data,kvs,rank, ownCheck)
             if rank: continue

--- a/inferelator_ng/bbsr_tfa_workflow.py
+++ b/inferelator_ng/bbsr_tfa_workflow.py
@@ -14,7 +14,6 @@ import datetime
 from kvsstcp.kvsclient import KVSClient
 import pandas as pd
 from . import utils
-import time
 
 # Connect to the key value store service (its location is found via an
 # environment variable that is set when this is started vid kvsstcp.py
@@ -59,7 +58,6 @@ class BBSR_TFA_Workflow(WorkflowBase):
             if rank: continue
             betas.append(current_betas)
             rescaled_betas.append(current_rescaled_betas)
-            kvs.put('bootstrap_{}'.format(idx + 1), 'go')
 
         self.emit_results(betas, rescaled_betas, self.gold_standard, self.priors_data)
 

--- a/inferelator_ng/bbsr_tfa_workflow.py
+++ b/inferelator_ng/bbsr_tfa_workflow.py
@@ -4,6 +4,7 @@ Run BSubtilis Network Inference with TFA BBSR.
 
 import numpy as np
 import os
+import sys
 from workflow import WorkflowBase
 import design_response_translation #added python design_response
 from tfa import TFA


### PR DESCRIPTION
@kostyat @dayanne-castro 

Calculating Mi and CLR and sending it to workers was sending a large amount of data to each worker per bootstrap. For example, for a 60k gene by 150 sample input file, the mi and clr matrices summed to .6 GB, and ended up being 1.6 GB of data once they were pickled. This was sent to 70 workers across 20 bootstraps on the cluster, leading to a massive (>10x) slowdown. 

Now, each worker calculates mi and clr independently, and needs to wait for a new special key (bootstrap %idx) before moving forward